### PR TITLE
Save and load composition class names automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ photo_composition/
 ```
 python photo_composition/train.py --data-dir <dataset_root> --epochs 10
 ```
+The command above saves the best model to `composition_model.pth` and
+records the detected class names in `composition_model_classes.json`.
 
 4. Predict composition for a new image:
 
 ```
 python photo_composition/predict.py --model composition_model.pth \
-    --class-names rule_of_thirds,centered,diagonal \
     --image path/to/photo.jpg
 ```
+By default the script reads class names from `composition_model_classes.json`.
+Use `--class-names` to override them.

--- a/photo_composition/predict.py
+++ b/photo_composition/predict.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+import json
 
 import torch
 from PIL import Image
@@ -25,7 +26,12 @@ def main(args):
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
     ])
 
-    class_names = args.class_names.split(',')
+    if args.class_names:
+        class_names = args.class_names.split(',')
+    else:
+        classes_file = args.model.with_name(args.model.stem + "_classes.json")
+        with classes_file.open() as f:
+            class_names = json.load(f)
     model = load_model(args.model, len(class_names), device)
 
     image = Image.open(args.image).convert("RGB")
@@ -41,7 +47,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Predict photo composition")
     parser.add_argument("--model", type=Path, required=True, help="Trained model file")
-    parser.add_argument("--class-names", type=str, required=True, help="Comma-separated list of class names")
+    parser.add_argument("--class-names", type=str, required=False, help="Comma-separated list of class names. If omitted, class names are loaded from <model>_classes.json")
     parser.add_argument("--image", type=Path, required=True, help="Image file to evaluate")
     parser.add_argument("--image-size", type=int, default=224)
     args = parser.parse_args()

--- a/photo_composition/train.py
+++ b/photo_composition/train.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+import json
 
 import torch
 from torch import nn
@@ -47,6 +48,8 @@ def main(args):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     train_loader, val_loader, class_names = create_dataloaders(args.data_dir, args.image_size, args.batch_size)
 
+    classes_file = args.output.with_name(args.output.stem + "_classes.json")
+
     model = CompositionNet(num_classes=len(class_names)).to(device)
     criterion = nn.CrossEntropyLoss()
     optimizer = Adam(model.parameters(), lr=args.lr)
@@ -63,6 +66,8 @@ def main(args):
         if val_acc > best_acc:
             best_acc = val_acc
             torch.save(model.state_dict(), args.output)
+            with classes_file.open("w") as f:
+                json.dump(class_names, f)
 
     print(f"Training finished. Best validation accuracy: {best_acc:.4f}")
 


### PR DESCRIPTION
## Summary
- persist class names as `<model>_classes.json` during training
- load class names from that file by default for prediction
- mention the new behaviour in the README

## Testing
- `python -m py_compile photo_composition/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6846cd38d04c8333b2629972b105e828