### PR TITLE
Fix dataset iteration and enable 4-channel predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@ records the detected class names in `composition_model_classes.json`.
 
 ```
 python photo_composition/predict.py --model composition_model.pth \
-    --image path/to/photo.jpg
+    --image path/to/photo.jpg --saliency path/to/photo_saliency.jpg
 ```
 By default the script reads class names from `composition_model_classes.json`.
 Use `--class-names` to override them.
-codex/save-class-names-to-json-and-update-predict.py
 
 5. Evaluate on a test dataset directory:
 
@@ -57,4 +56,3 @@ python photo_composition/evaluate.py --model composition_model.pth \
 This prints the classification accuracy on the provided dataset. When
 `--class-names` is omitted, the script loads class names from
 `composition_model_classes.json`.
-main

--- a/photo_composition/dataset.py
+++ b/photo_composition/dataset.py
@@ -83,8 +83,13 @@ class FourChannelImageFolder(Dataset):
         self.samples = []
         for class_name in os.listdir(image_dir):
             class_path = os.path.join(image_dir, class_name)
+            if not os.path.isdir(class_path):
+                continue
             for fname in os.listdir(class_path):
-                img_path = os.path.join(class_path, fname)
+                file_path = os.path.join(class_path, fname)
+                if os.path.isdir(file_path):  # e.g. "saliency" directory
+                    continue
+                img_path = file_path
                 sal_path = os.path.join(class_path, self.saliency_dir, fname)  # 同名ファイルを前提
                 self.samples.append((img_path, sal_path, self.class_to_idx[class_name]))
 

--- a/photo_composition/evaluate.py
+++ b/photo_composition/evaluate.py
@@ -68,7 +68,7 @@ def main(args):
 
     model = load_model(args.model, len(class_names), device)
 
-    acc = evaluate(model, loader, device)
+    acc = evaluate(model, loader, device, class_names)
     print(f"Test accuracy: {acc:.4f}")
 
 

--- a/photo_composition/predict.py
+++ b/photo_composition/predict.py
@@ -35,7 +35,11 @@ def main(args):
     model = load_model(args.model, len(class_names), device)
 
     image = Image.open(args.image).convert("RGB")
-    tensor = transform(image).unsqueeze(0).to(device)
+    saliency = Image.open(args.saliency).convert("L")
+
+    rgb_tensor = transform(image)
+    saliency_tensor = transform(saliency)
+    tensor = torch.cat([rgb_tensor, saliency_tensor], dim=0).unsqueeze(0).to(device)
     with torch.no_grad():
         outputs = model(tensor)
         probs = torch.softmax(outputs, dim=1)[0]
@@ -49,6 +53,7 @@ if __name__ == "__main__":
     parser.add_argument("--model", type=Path, required=True, help="Trained model file")
     parser.add_argument("--class-names", type=str, required=False, help="Comma-separated list of class names. If omitted, class names are loaded from <model>_classes.json")
     parser.add_argument("--image", type=Path, required=True, help="Image file to evaluate")
+    parser.add_argument("--saliency", type=Path, required=True, help="Corresponding saliency map")
     parser.add_argument("--image-size", type=int, default=224)
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
## Summary
- skip saliency directory when listing images in `FourChannelImageFolder`
- update `predict.py` to accept saliency images and build a 4‑channel tensor
- pass class names to `evaluate()`
- clean up README and document new `--saliency` option

## Testing
- `python -m py_compile photo_composition/dataset.py`
- `python -m py_compile photo_composition/evaluate.py`
- `python -m py_compile photo_composition/predict.py`


------
https://chatgpt.com/codex/tasks/task_e_684962e69af48333a7f4cd3244729a80